### PR TITLE
Fix 1.19 Quilt support

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -22,7 +22,7 @@
     "mcg.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.14.8",
+    "fabricloader": ">=0.14.7",
     "minecraft": "1.19.x"
   }
 }


### PR DESCRIPTION
The current latest "Quilted Fabric API / Quilt Standard Libraries" uses Fabric API 0.57.0 and Fabric Loader 0.14.7. Lowering the required version of Fabric Loader from >=0.14.8 to >=0.14.7 should fix support for MCG on Quilt 1.19, without impacting any features or support for standard Fabric.